### PR TITLE
Refactor domain scaffolding commands and tidy provider

### DIFF
--- a/src/Commands/Concerns/HandlesStubCallbacks.php
+++ b/src/Commands/Concerns/HandlesStubCallbacks.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AesirCloud\LaravelDomains\Commands\Concerns;
+
+trait HandlesStubCallbacks
+{
+    protected function logger(): callable
+    {
+        return function (string $message, bool $warn = false): void {
+            $warn ? $this->warn($message) : $this->info($message);
+        };
+    }
+
+    protected function confirmOverwrite(): callable
+    {
+        return function (string $question, bool $default = true): bool {
+            return $this->confirm($question, $default);
+        };
+    }
+}

--- a/src/Helpers/DomainCommandHelper.php
+++ b/src/Helpers/DomainCommandHelper.php
@@ -57,22 +57,21 @@ class DomainCommandHelper
             $contents = str_replace($search, $replace, $contents);
         }
 
-        // Create or overwrite the file
-        if (File::exists($destination) && ! $forceOverwrite) {
-            // If user does not confirm, skip
+        $existed = File::exists($destination);
+        if ($existed && ! $forceOverwrite) {
             if (! $confirmCallback("File {$destination} already exists. Overwrite it?", true)) {
                 $logger("Skipped file: {$destination}");
                 return;
             }
         }
 
-        File::put($destination, $contents);
-
-        if (File::exists($destination)) {
-            $logger("Created/Replaced file: {$destination}");
-        } else {
-            $logger("Created file: {$destination}");
+        $result = File::put($destination, $contents);
+        if ($result === false) {
+            $logger("Failed to write file: {$destination}", true);
+            return;
         }
+
+        $logger(($existed ? 'Replaced' : 'Created') . " file: {$destination}");
     }
 
     /**

--- a/src/Providers/DomainServiceProvider.php
+++ b/src/Providers/DomainServiceProvider.php
@@ -9,11 +9,6 @@ use Illuminate\Support\ServiceProvider;
 
 class DomainServiceProvider extends ServiceProvider
 {
-    public function register()
-    {
-        //
-    }
-
     public function boot()
     {
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
## Summary
- refactor `make:domain` into smaller steps and share IO callbacks with subdomain command
- simplify stub file generation and add reusable logger trait
- drop empty register method from `DomainServiceProvider`

## Testing
- `composer install` (fails: curl error 56 while downloading packages)
- `./vendor/bin/pest` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68bc4fe89d20832c9392155f6a7b34f5